### PR TITLE
Improve error messages when react-tools transform fails

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -19,7 +19,15 @@ jshintcli.__set__("lint", function myLint(code, results, config, data, file) {
         code = '/** @jsx React.DOM */' + code;
     }
     if (isJsxFile || hasDocblock) {
-        origLint(react.transform(code), results, config, data, file);
+        var compiled;
+
+        try {
+            compiled = react.transform(code);
+        } catch (err) {
+            throw new Error('grunt-jsxhint: Error while running JSXTransformer on ' + file + '\n' + err.message);
+        }
+
+        origLint(compiled, results, config, data, file);
     }
   else {
     origLint(code, results, config, data, file);


### PR DESCRIPTION
I've had some syntax errors that just ended up with a lot of research work because I didn't log the file that was failing in the compile step. This should help
