### PR TITLE
Adds support for custom extensions to be parsed by react-tools

### DIFF
--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -10,7 +10,7 @@ try {
 
 var jshintcli = rewire('jshint/src/cli');
 
-//Get the original lint function 
+//Get the original lint function
 var origLint = jshintcli.__get__('lint');
 
 
@@ -49,7 +49,7 @@ jshintcli.__set__('lint', function myLint(code, results, config, data, file) {
   }
 });
 
-//override the jshint cli in the grunt-contrib-jshint lib folder 
+//override the jshint cli in the grunt-contrib-jshint lib folder
 var libJsHint = proxyquire('grunt-contrib-jshint/tasks/lib/jshint', {
   'jshint/src/cli': jshintcli
 });
@@ -61,4 +61,36 @@ var gruntContribJshint = proxyquire('grunt-contrib-jshint/tasks/jshint', {
 });
 
 //return the modified grunt-contrib-jshint version
-module.exports = gruntContribJshint;
+module.exports = function(grunt) {
+
+  var origJsHint = 'jshint-original';
+
+  // Registers jshint task
+  gruntContribJshint.apply(this,[grunt]);
+
+  // Rename the task, so we can use it
+  grunt.task.renameTask('jshint', origJsHint);
+
+  // Set jshint-original targets
+  grunt.config.data[origJsHint] = grunt.config.data.jshint;
+
+  // Register our MultiTask
+  grunt.task.registerMultiTask('jshint', 'Validate files with JSXHint.', function() {
+    var options = this.options();
+
+    if(options.extensions) {
+
+      // to follow the same pattern as used by jshint-cli.js
+      var exts = options.extensions.split(',');
+      exts.map(function(e) {
+        e = e.replace(/[ ]/g, "");
+        if(e) {
+          defaultSuffixes.push(e);
+        }
+      });
+    }
+
+    // And call the original JSHINT task
+    grunt.task.run([origJsHint]);
+  });
+};


### PR DESCRIPTION
Fixes #15 .

This looks like a hacky solution - mutating grunt config and using global var as a state object, but works!

Try it out and let me know. We can either append to defaultExtensions or replace them.