### PR TITLE
List react-tools as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,11 +24,9 @@
     "grunt-contrib-jshint": "0.11.1",
     "jshint": "~2.6.0"
   },
-  "devDependencies": {
-    "react-tools": "~0.13.0"
-  },
   "peerDependencies": {
-    "grunt": "~0.4.0"
+    "grunt": "~0.4.0",
+    "react-tools": "~0.13.0"
   },
   "keywords": [
     "gruntplugin",

--- a/tasks/jshint.js
+++ b/tasks/jshint.js
@@ -1,14 +1,7 @@
-var rewire = require('rewire');
-var proxyquire = require('proxyquire');
-
-try {
-  var react = require('react-tools');
-} catch (e) {
-  throw new Error('grunt-jsxhint: The module `react-tools` was not found. ' +
-    'To fix this error run `npm install react-tools --save-dev`.', e);
-}
-
 var jshintcli = rewire('jshint/src/cli');
+var proxyquire = require('proxyquire');
+var react = require('react-tools');
+var rewire = require('rewire');
 
 //Get the original lint function
 var origLint = jshintcli.__get__('lint');


### PR DESCRIPTION
Hi,

`react-tools` can be listed as a peerDependency and have npm to warn in case it's not installed. Therefore, avoiding the runtime check.