### PR TITLE
Make `react-tools` become the dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,7 @@
     "proxyquire": "~1.4.0",
     "rewire": "~2.3.1",
     "grunt-contrib-jshint": "0.11.1",
-    "jshint": "~2.6.0"
-  },
-  "devDependencies": {
+    "jshint": "~2.6.0",
     "react-tools": "~0.13.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
When I install this module, then the `react-tools was not found` error will appear.
This commit resolve this error.